### PR TITLE
Redirect if no vaultAddress is found

### DIFF
--- a/src/pages/Vault/Vault.tsx
+++ b/src/pages/Vault/Vault.tsx
@@ -70,6 +70,7 @@ import { ThemeInterface } from 'types/ui';
 import { VaultTab } from 'enums/vault';
 import { stableCoinParser } from 'utils/formatters/ethers';
 import { getDefaultCollateral } from 'utils/collaterals';
+import { navigateTo } from 'utils/routes';
 
 type VaultProps = RouteComponentProps<{
     vaultId: string;
@@ -93,8 +94,14 @@ const Vault: React.FC<VaultProps> = (props) => {
     const [lastValidUserVaultData, setLastValidUserVaultData] = useState<UserVaultData | undefined>(undefined);
 
     const { params } = props.match;
-    const vaultId = params && params.vaultId ? params.vaultId : '';
-    const vaultAddress = !!VAULT_MAP[vaultId] ? VAULT_MAP[vaultId].addresses[networkId] : undefined;
+    const vaultId = params && params.vaultId && !!VAULT_MAP[params.vaultId] ? params.vaultId : '';
+    const vaultAddress = !!vaultId ? VAULT_MAP[vaultId].addresses[networkId] : undefined;
+
+    useEffect(() => {
+        if (!vaultAddress) {
+            navigateTo(ROUTES.Vaults);
+        }
+    }, []);
 
     const { openConnectModal } = useConnectModal();
 


### PR DESCRIPTION
If no vaultId is set in URL parameters or if vaultAddress is not found with this vaultId, redirect to vaults list page

Examples :

https://overtimemarkets.xyz/#/vaults/discount-vault => OK
https://overtimemarkets.xyz/#/vaults/discount-test => KO, redirect to vaults list